### PR TITLE
feat: educator child management and activity dot metadata support

### DIFF
--- a/src/activities/activities.service.ts
+++ b/src/activities/activities.service.ts
@@ -147,9 +147,30 @@ export class ActivitiesService {
     return this.activitiesData.questions.find((q) => q.id === questionId);
   }
 
+  private mergeMetadataFields(dto: CreateActivityDto | UpdateActivityDto): Record<string, unknown> {
+    const presentationKeys = [
+      'key', 'label', 'icon', 'title', 'subtitle',
+      'snippet', 'description', 'paragraph1', 'paragraph2', 'media',
+    ] as const;
+
+    const merged: Record<string, unknown> = { ...(dto.metadata || {}) };
+
+    for (const field of presentationKeys) {
+      if ((dto as any)[field] !== undefined) {
+        merged[field] = (dto as any)[field];
+      }
+    }
+
+    return merged;
+  }
+
+  private stripPresentationFields(dto: CreateActivityDto | UpdateActivityDto): Omit<typeof dto, 'key' | 'label' | 'icon' | 'title' | 'subtitle' | 'snippet' | 'description' | 'paragraph1' | 'paragraph2' | 'media'> {
+    const { key, label, icon, title, subtitle, snippet, description, paragraph1, paragraph2, media, ...rest } = dto as any;
+    return rest;
+  }
+
   // CRUD operations for entity-based activities
   async createActivity(createActivityDto: CreateActivityDto): Promise<Activity> {
-    // Verify that the assessment exists
     const assessment = await this.assessmentRepository.findOne({
       where: { id: createActivityDto.assessmentId },
     });
@@ -160,7 +181,10 @@ export class ActivitiesService {
       );
     }
 
-    const activity = this.activityRepository.create(createActivityDto);
+    const metadata = this.mergeMetadataFields(createActivityDto);
+    const entityData = this.stripPresentationFields(createActivityDto);
+
+    const activity = this.activityRepository.create({ ...entityData, metadata });
     return await this.activityRepository.save(activity);
   }
 
@@ -195,7 +219,6 @@ export class ActivitiesService {
   async updateActivity(id: string, updateActivityDto: UpdateActivityDto): Promise<Activity> {
     const activity = await this.findOneActivity(id);
 
-    // If assessmentId is being updated, verify the new assessment exists
     if (updateActivityDto.assessmentId && updateActivityDto.assessmentId !== activity.assessmentId) {
       const assessment = await this.assessmentRepository.findOne({
         where: { id: updateActivityDto.assessmentId },
@@ -208,7 +231,13 @@ export class ActivitiesService {
       }
     }
 
-    Object.assign(activity, updateActivityDto);
+    const metadata = this.mergeMetadataFields({
+      ...updateActivityDto,
+      metadata: { ...(activity.metadata || {}), ...(updateActivityDto.metadata || {}) },
+    });
+    const entityData = this.stripPresentationFields(updateActivityDto);
+
+    Object.assign(activity, entityData, { metadata });
     return await this.activityRepository.save(activity);
   }
 

--- a/src/activities/dto/create-activity.dto.ts
+++ b/src/activities/dto/create-activity.dto.ts
@@ -17,8 +17,48 @@ export class CreateActivityDto {
   @IsOptional()
   attribute?: string;
 
+  @IsString()
+  @IsOptional()
+  key?: string;
+
+  @IsString()
+  @IsOptional()
+  label?: string;
+
+  @IsString()
+  @IsOptional()
+  icon?: string;
+
+  @IsString()
+  @IsOptional()
+  title?: string;
+
+  @IsString()
+  @IsOptional()
+  subtitle?: string;
+
+  @IsString()
+  @IsOptional()
+  snippet?: string;
+
+  @IsString()
+  @IsOptional()
+  description?: string;
+
+  @IsString()
+  @IsOptional()
+  paragraph1?: string;
+
+  @IsString()
+  @IsOptional()
+  paragraph2?: string;
+
+  @IsString()
+  @IsOptional()
+  media?: string;
+
   @IsObject()
   @IsOptional()
-  metadata?: any;
+  metadata?: Record<string, unknown>;
 }
 

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -51,6 +51,7 @@ export class AuthService {
         username: savedPerson.username,
         name: savedPerson.name,
         yob: savedPerson.yob,
+        role: savedPerson.role,
       },
     };
   }
@@ -85,6 +86,7 @@ export class AuthService {
         username: person.username,
         name: person.name,
         yob: person.yob,
+        role: person.role,
       },
     };
   }
@@ -103,6 +105,7 @@ export class AuthService {
       username: person.username,
       name: person.name,
       yob: person.yob,
+      role: person.role,
     };
   }
 }

--- a/src/auth/roles.decorator.ts
+++ b/src/auth/roles.decorator.ts
@@ -1,0 +1,4 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const ROLES_KEY = 'roles';
+export const Roles = (...roles: string[]) => SetMetadata(ROLES_KEY, roles);

--- a/src/auth/roles.guard.ts
+++ b/src/auth/roles.guard.ts
@@ -1,0 +1,22 @@
+import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { ROLES_KEY } from './roles.decorator';
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(private reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const requiredRoles = this.reflector.getAllAndOverride<string[]>(ROLES_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    if (!requiredRoles) {
+      return true;
+    }
+
+    const { user } = context.switchToHttp().getRequest();
+    return requiredRoles.includes(user?.role);
+  }
+}

--- a/src/entities/activity.entity.ts
+++ b/src/entities/activity.entity.ts
@@ -2,6 +2,20 @@ import { Entity, Column, PrimaryGeneratedColumn, ManyToOne, JoinColumn } from 't
 import { CommonEntity } from './common.entity';
 import { Assessment } from './assessment.entity';
 
+export interface ActivityMetadata {
+  key?: string;
+  label?: string;
+  icon?: string;
+  title?: string;
+  subtitle?: string;
+  snippet?: string;
+  description?: string;
+  paragraph1?: string;
+  paragraph2?: string;
+  media?: string;
+  [extra: string]: unknown;
+}
+
 @Entity('activities')
 export class Activity extends CommonEntity {
   @PrimaryGeneratedColumn('uuid')
@@ -24,6 +38,6 @@ export class Activity extends CommonEntity {
   attribute: string;
 
   @Column({ type: 'jsonb', nullable: true })
-  metadata: any;
+  metadata: ActivityMetadata;
 }
 

--- a/src/person/person.controller.ts
+++ b/src/person/person.controller.ts
@@ -11,10 +11,14 @@ import {
   Put,
   Delete,
   Version,
+  UseGuards,
 } from '@nestjs/common';
 import { PersonService } from './person.service';
 import { CreatePersonDto } from './dto/create-person.dto';
 import { UpdatePersonDto } from './dto/update-person.dto';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { RolesGuard } from '../auth/roles.guard';
+import { Roles } from '../auth/roles.decorator';
 
 @Controller({
   path: 'persons',
@@ -22,6 +26,22 @@ import { UpdatePersonDto } from './dto/update-person.dto';
 })
 export class PersonController {
   constructor(private readonly personService: PersonService) {}
+
+  @Get('my-children')
+  @Version('1')
+  @UseGuards(RolesGuard)
+  @Roles('educator')
+  async getMyChildren(@CurrentUser() user: any) {
+    return this.personService.getMyChildren(user.id);
+  }
+
+  @Post('add-child')
+  @Version('1')
+  @UseGuards(RolesGuard)
+  @Roles('educator')
+  async addChild(@CurrentUser() user: any, @Body() dto: CreatePersonDto) {
+    return this.personService.addChild(user.id, dto);
+  }
 
   @Get()
   @Version('1')

--- a/src/person/person.service.ts
+++ b/src/person/person.service.ts
@@ -1,15 +1,19 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Person } from '../entities/person.entity';
+import { Relationships } from '../entities/relationships.entity';
 import { IsNull, Repository } from 'typeorm';
 import { CreatePersonDto } from './dto/create-person.dto';
 import { UpdatePersonDto } from './dto/update-person.dto';
+import * as bcrypt from 'bcrypt';
 
 @Injectable()
 export class PersonService {
   constructor(
     @InjectRepository(Person)
     private readonly personRepository: Repository<Person>,
+    @InjectRepository(Relationships)
+    private readonly relationshipsRepository: Repository<Relationships>,
   ) {}
 
   async getAllPersons(page: number, limit: number): Promise<any> {
@@ -81,5 +85,63 @@ export class PersonService {
 
     const successMsg = `Person with id ${personId} has been soft deleted.`;
     return successMsg;
+  }
+
+  async getMyChildren(educatorId: string): Promise<any> {
+    const relationships = await this.relationshipsRepository.find({
+      where: {
+        personId: educatorId,
+        relationType: 'educator',
+      },
+      relations: ['relatedPerson'],
+    });
+
+    return relationships
+      .filter((r) => r.relatedPerson && !r.relatedPerson.deletedAt)
+      .map((r) => {
+        const person = r.relatedPerson!;
+        return {
+          id: person.id,
+          name: person.name,
+          username: person.username,
+          yob: person.yob,
+          role: person.role,
+          createdAt: person.createdAt,
+        };
+      });
+  }
+
+  async addChild(
+    educatorId: string,
+    dto: CreatePersonDto,
+  ): Promise<any> {
+    const hashedPassword = await bcrypt.hash(dto.name.toLowerCase().replace(/\s+/g, '_'), 10);
+
+    const child = this.personRepository.create({
+      name: dto.name,
+      yob: dto.yob,
+      username: `${dto.name.toLowerCase().replace(/\s+/g, '_')}_${Date.now()}`,
+      password: hashedPassword,
+      role: 'user',
+    });
+
+    const savedChild = await this.personRepository.save(child);
+
+    const relationship = this.relationshipsRepository.create({
+      personId: educatorId,
+      relatedPersonId: savedChild.id,
+      relationType: 'educator',
+    });
+
+    await this.relationshipsRepository.save(relationship);
+
+    return {
+      id: savedChild.id,
+      name: savedChild.name,
+      username: savedChild.username,
+      yob: savedChild.yob,
+      role: savedChild.role,
+      createdAt: savedChild.createdAt,
+    };
   }
 }

--- a/src/responses/responses.service.ts
+++ b/src/responses/responses.service.ts
@@ -178,7 +178,7 @@ export class ResponsesService {
     const attribute = activity.attribute || activity.domain;
 
     // Get score adjustment from metadata options
-    const options = activity.metadata?.options || [];
+    const options = (activity.metadata?.options || []) as Array<{ value: number; label: string; scoreAdjustment: number }>;
     const selectedOption = options.find((opt: any) => opt.value === optionValue);
 
     if (!selectedOption) {


### PR DESCRIPTION
Adds educator-scoped endpoints for managing children (students) and merges DotData presentation fields into activity metadata on create/update.

- person: add GET /persons/my-children and POST /persons/add-child endpoints guarded by RolesGuard with 'educator' role; addChild auto-generates a username and hashed password from the child's name
- activity entity: type ActivityMetadata interface (key, label, icon, title, subtitle, snippet, description, paragraph1, paragraph2, media) replacing loose `any` on the metadata column
- activities service: mergeMetadataFields/stripPresentationFields helpers fold top-level DotData fields from CreateActivityDto/UpdateActivityDto into the metadata JSONB column transparently
- auth: add RolesGuard and Roles decorator
- activities dto: add presentation fields to CreateActivityDto